### PR TITLE
Fix classify defaulting when only one label.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+.vscode

--- a/assets/scripts/whichx.js
+++ b/assets/scripts/whichx.js
@@ -8,7 +8,7 @@ function WhichX() {
     // The word total represents the total number of words added against that label.
     var typesMap = {
         // Total must exist and be incremented for probability calculations.
-        "total": { "tcount": 0, "wordTotal": 0 }
+        "total": { "tcount": 0, "wordTotal": 1 }
     };
 
     // Add a label or list of labels to the classifier
@@ -34,8 +34,8 @@ function WhichX() {
         var type, wordArray, i, word;
         var total = typesMap.total;
 
-        if (label in typesMap && typeof description === "string") {
-            type = typesMap[label];
+        if (label.toLowerCase() in typesMap && typeof description === "string") {
+            type = typesMap[label.toLowerCase()];
             type.tcount = type.tcount + 1;
             total.tcount = total.tcount + 1;
             wordArray = processToArray(description);
@@ -70,7 +70,7 @@ function WhichX() {
 
         if (typeof description === "string" && description.length > 0) {
             wordArray = processToArray(description);
-            bestChance = 0;
+            bestChance = -1;
             bestLabel = undefined;
 
             // Loop through types working out the chance of the description being
@@ -92,7 +92,7 @@ function WhichX() {
     };
 
     // Exports the WhichX internal data representation learned from provided
-    // labeled text. Please see th typesMap comments for more details.
+    // labeled text. Please see the typesMap comments for more details.
     this.export = function() {
         return typesMap;
     };

--- a/assets/scripts/whichx.js
+++ b/assets/scripts/whichx.js
@@ -71,7 +71,7 @@ function WhichX() {
         if (typeof description === "string" && description.length > 0) {
             wordArray = processToArray(description);
             bestChance = 0;
-            bestLabel = "pet";
+            bestLabel = undefined;
 
             // Loop through types working out the chance of the description being
             // for this type. If better than bestChance then bestChange <- chance.

--- a/test/tests.js
+++ b/test/tests.js
@@ -45,6 +45,10 @@
             it("object should have key vars hidden", function() {
                 assert.ok(!(classifier.typesMap) && !(classifier.STOPWORDS) && !(classifier.processToArray));
             });
+
+            it("object should have default classify value", function() {
+                assert.equal(classifier.classify("no labels"), undefined);
+            });
         });
 
         describe("labels", function() {
@@ -114,6 +118,13 @@
             classifier.addData("dog", "bark woof wag fetch");
 
             classificationAssertions(classifier);
+
+            it("should successfully classify with only 1 label", function() {
+                classifier = new Whichx();
+                classifier.addLabels("pokemon");
+                classifier.addData("pokemon", "pikachu yellow lightning");
+                assert.equal(classifier.classify("pokemanz?"), "pokemon");
+            });
         });
 
         describe("imported export", function() {


### PR DESCRIPTION
When there is only 1 label the Bayes Theorum calculation fail with a divide by 0 error. Have changed the default total word count to 1 so that a divide by 0 should never happen.